### PR TITLE
fix: undo will not refresh the current task list

### DIFF
--- a/apps/frontend/src/components/task/TaskItem.vue
+++ b/apps/frontend/src/components/task/TaskItem.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import { NPopover } from 'naive-ui'
-import type { Task } from 'services/task'
+import type { Project, Task } from 'services/task'
 import { changeTaskTitle } from 'services/task'
 import { useTaskOperationMessage, useTaskRightContextMenu } from '@/composable'
 import { TaskState, useTaskStore, useThemeStore } from '@/store'
 
 interface Props {
   task: Task
+  project: Project
 }
 
 const props = defineProps<Props>()
@@ -40,7 +41,7 @@ function handleInput(e: Event, task: Task) {
 function handleCompleteTodo(e: Event) {
   if (props.task.state === TaskState.ACTIVE) {
     taskStore.completeTask(props.task)
-    showCompleteMessage(props.task)
+    showCompleteMessage(props.task, props.project)
   }
   else if (props.task.state === TaskState.COMPLETED) {
     taskStore.restoreTask(props.task)

--- a/apps/frontend/src/components/task/TaskList.vue
+++ b/apps/frontend/src/components/task/TaskList.vue
@@ -119,7 +119,7 @@ const { inputRef, onFocus } = useInput()
       @end="dragging = false"
     >
       <template #item="{ element, index }">
-        <TaskItem :task="element" :index="index" class="item" />
+        <TaskItem :project="taskStore.currentActiveProject" :task="element" :index="index" class="item" />
       </template>
     </draggable>
     <!-- 暂时性修复 contenteditable 的 bug #9 -->

--- a/apps/frontend/src/composable/useTaskOperationMessage.ts
+++ b/apps/frontend/src/composable/useTaskOperationMessage.ts
@@ -1,7 +1,7 @@
 import type { MessageReactive } from 'naive-ui'
 import { createDiscreteApi } from 'naive-ui'
 import { h } from 'vue'
-import type { Task } from 'services/task'
+import type { Project, Task } from 'services/task'
 import { useTaskStore } from '@/store'
 
 enum TaskOperationStatus {
@@ -40,9 +40,11 @@ export function useTaskOperationMessage() {
     }
   }
 
-  function showCompleteMessage(task: Task) {
+  function showCompleteMessage(task: Task, project: Project) {
     const onClick = () => {
       taskStore.restoreTask(task)
+      // 撤销后刷新当前展示的task列表
+      taskStore.selectProject(project)
       removeMessage()
     }
     const content = `${task.title} ${TaskOperationStatus.Complete}`


### PR DESCRIPTION
问题：撤销操作后，当前的task列表没有更新
before:
![128b](https://user-images.githubusercontent.com/41691876/215254410-d3ee50b5-c420-4122-83fd-e1d4d0af9ce2.gif)

after:
![128a](https://user-images.githubusercontent.com/41691876/215254414-671e19cd-9b73-4f13-b648-ea6962840179.gif)
