### PR TITLE
feat: disallow dragging in smart projects

### DIFF
--- a/apps/frontend/src/components/task/TaskItem.vue
+++ b/apps/frontend/src/components/task/TaskItem.vue
@@ -8,6 +8,7 @@ import { TaskState, useTaskStore, useThemeStore } from '@/store'
 interface Props {
   task: Task
   project: Project
+  isShowDragIcon: boolean
 }
 
 const props = defineProps<Props>()
@@ -60,6 +61,7 @@ function handleCompleteTodo(e: Event) {
     @click.right="handleRightClickTask($event, task)"
   >
     <i
+      v-if="props.isShowDragIcon"
       class="cursor-move text-gray-200 dark:text-#3B3B3B flex-shrink-0 i-mdi-format-align-justify text-sm"
     />
     <div

--- a/apps/frontend/src/components/task/TaskList.vue
+++ b/apps/frontend/src/components/task/TaskList.vue
@@ -3,7 +3,7 @@ import type { Ref } from 'vue'
 import { computed, ref } from 'vue'
 import { Icon } from '@iconify/vue'
 import draggable from 'vuedraggable'
-import { isSmartProject, updateTaskIndex } from 'services/task'
+import { SmartProjectNames, isSmartProject, updateTaskIndex } from 'services/task'
 import Command from '../command/Command.vue'
 import TaskItem from './TaskItem.vue'
 import {
@@ -61,6 +61,12 @@ const shouldShowTodoAdd = computed(() => {
   const name = taskStore.currentActiveProject?.name || ''
   return !isSmartProject(name)
 })
+
+const shouldEnabledDrag = computed(() =>
+  !Object.values(SmartProjectNames).includes(
+    taskStore.currentActiveProject?.name as SmartProjectNames,
+  ),
+)
 
 const { inputRef, onFocus } = useInput()
 
@@ -141,6 +147,7 @@ function handleEndDrag(e: any) {
         name: !dragging ? 'flip-list' : null,
       }"
       class="flex flex-col gap-10px"
+      :disabled="!shouldEnabledDrag"
       @start="dragging = true"
       @end="handleEndDrag"
     >

--- a/apps/frontend/src/components/task/TaskList.vue
+++ b/apps/frontend/src/components/task/TaskList.vue
@@ -156,6 +156,7 @@ function handleEndDrag(e: any) {
           :project="taskStore.currentActiveProject"
           :task="element"
           :index="index"
+          :is-show-drag-icon="shouldEnabledDrag"
           class="item"
         />
       </template>


### PR DESCRIPTION
https://github.com/cuixueshe/dida/issues/134
通过判断当前的 `taskStore.currentActiveProject.name` 是否在 `SmartProjectNames` 中，不启用拖拽
```ts
export enum SmartProjectNames {
  Complete = '已完成',
  Trash = '垃圾桶',
  Failed = '已放弃',
  Abstract = '摘要',
}
```