### PR TITLE
feat: active project is the newly created project

### DIFF
--- a/apps/frontend/src/components/task/TaskLeftListProject.vue
+++ b/apps/frontend/src/components/task/TaskLeftListProject.vue
@@ -130,6 +130,13 @@ watchEffect(() => {
   treeTagChildren.value = generateTagChildrenNode(taskStore.listTags)
 })
 
+watchEffect(() => {
+  const key = treeProjectChildren.value.find(v =>
+    v.label === taskStore.currentActiveProject?.name,
+  )?.key
+  key && projectSelectedStatusStore.changeSelectedKey([+key])
+})
+
 onMounted(() => {
   defaultExpandedKeys.value = [
     ...new Set([


### PR DESCRIPTION
https://github.com/cuixueshe/dida/issues/133
创建 project 后 `taskStore.currentActiveProject` 是有变化的，但是 `projectSelectedStatusStore.selectedKey` 并没有变化。所以监听 `taskStore.currentActiveProject` 的变化，调用 `projectSelectedStatusStore.changeSelectedKey()` 方法改变 `projectSelectedStatusStore.selectedKey`。
```ts
watchEffect(() => {
  const key = treeProjectChildren.value.find(v =>
    v.label === taskStore.currentActiveProject?.name,
  )?.key
  key && projectSelectedStatusStore.changeSelectedKey([+key])
})
```