### PR TITLE
fix:let the TaskItem of COMPLETED and REMOVED self-adaption

### DIFF
--- a/apps/frontend/src/pages/Task.vue
+++ b/apps/frontend/src/pages/Task.vue
@@ -56,7 +56,7 @@ const taskLeftMenuStatusStore = useTaskLeftMenuStatusStore()
       title="收缩侧边栏"
       @mousedown.prevent="useDividerLeftDrag"
     />
-    <div class="flex-1 flex w-full h-full p-24px">
+    <div class="flex-1 flex w-full h-full p-24px min-w-300px">
       <TaskList class="w-full" />
     </div>
     <div


### PR DESCRIPTION
当窗口小到一定程度的时候，已完成和垃圾桶那块的 taskitem会发生混乱
<img width="836" alt="image" src="https://user-images.githubusercontent.com/65757184/218672837-f8d49579-469e-4db0-9244-df4b367e30cc.png">
